### PR TITLE
Add component option to prompt package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-modals-lib.js",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Async Modals Lib",
   "main": "confirm.js",
   "scripts": {

--- a/packages/prompt/index.d.ts
+++ b/packages/prompt/index.d.ts
@@ -8,6 +8,7 @@ interface IPromptOptions {
   closable?: boolean;
   animation?: 'ease' | 'slide' | 'verticalSlide';
   width?: number;
+  component?: 'input' | 'textarea';
 }
 
 export default function (options: IPromptOptions): Promise<string>;

--- a/packages/prompt/index.js
+++ b/packages/prompt/index.js
@@ -8,10 +8,18 @@ const promptModal = async (options) => {
   const defaultValue = options.defaultValue || '';
   const placeholder = options.placeholder || '';
 
+  const component = options.component ? options.component : 'input';
+  if (component !== 'input' && component !== 'textarea') {
+    throw new Error('Invalid component type');
+  }
+  let templateElement = `<input class="amljs-prompt-input" placeholder="${placeholder}" type="text" />`;
+  if (component === 'textarea') {
+    templateElement = `<textarea class="amljs-prompt-input" placeholder="${placeholder}"></textarea>`;
+  }
   const template = `
     ${title ? `<div class="amljs-prompt-title">${title}</div>` : ''}
     ${message ? `<div class="amljs-prompt-message">${message}</div>` : ''}
-    <input class="amljs-prompt-input" placeholder="${placeholder}" type="text" />
+    ${templateElement}
     <button class="amljs-button amljs-prompt-button amljs-button--ok">${buttonText}</button>
   `;
 
@@ -39,7 +47,7 @@ const promptModal = async (options) => {
   input.value = value;
   input.addEventListener('keyup', (e) => {
     value = e.target.value;
-    if (e.keyCode === 13) {
+    if (e.keyCode === 13 && component === 'input') {
       resolver(value);
     }
   });


### PR DESCRIPTION
Introduced 'component' parameter to prompt package which lets the user specify whether to use an "input" field or a "textarea" field. An error is thrown if an invalid component type is entered. Also added a condition that is the 'Enter' key to trigger the resolver only if the component is an "input". Updated the package version in package.json.